### PR TITLE
Fixing the CI by lowering the cmdliner minimal version

### DIFF
--- a/opam/ez_cmdliner.opam
+++ b/opam/ez_cmdliner.opam
@@ -40,7 +40,7 @@ depends: [
   "dune" {>= "2.7.0"}
   "ocplib_stuff" {>= "0.3"}
   "ez_subst" {>= "0.1"}
-  "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "cmdliner" {>= "1.0.4" & < "2.0.0"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
cmdliner.1.1.0 depends on ocaml >= 4.08.0, which is not possible with the CI checking installation with ocaml=4.07.0