### PR TITLE
Fix RST generation to conform to Sphinx/docutils syntax requirements

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -17,6 +17,7 @@
    (ocplib_stuff ( >= 0.3 ))
    (ez_subst ( >= 0.1 ))
    (cmdliner (and (>= 1.1.0) (< 2.0.0)))
+   re
    ppx_inline_test
    ppx_expect
    odoc

--- a/opam/ez_cmdliner.opam
+++ b/opam/ez_cmdliner.opam
@@ -41,6 +41,7 @@ depends: [
   "ocplib_stuff" {>= "0.3"}
   "ez_subst" {>= "0.1"}
   "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "re"
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}

--- a/src/ez_cmdliner/dune
+++ b/src/ez_cmdliner/dune
@@ -4,7 +4,7 @@
   (name ezcmd)
   (public_name ez_cmdliner)
   (wrapped true)
-  (libraries ocplib_stuff ez_subst cmdliner )
+  (libraries ocplib_stuff ez_subst cmdliner re)
   
   
   )


### PR DESCRIPTION
- Add `escape_rst` function to escape `*, backquote, |, _` characters that could be misinterpreted as RST formatting
- Add `indent_lines` function for multi-line text in list items
- Add `replace_all` helper for string substitution
- Update `doclang_to_rst` to escape special chars while preserving intentional bold/italic formatting from `$(b,...)` and `$(i,...)` markers
- Track list state in `man_to_rst` to add blank lines after lists
- Add trailing newline after `print_options`

These changes eliminate Sphinx warnings like "Bullet list ends without a blank line" and "Inline emphasis start-string without end-string".