### PR TITLE
Fix deprecation warning on `Printf.kprintf`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## unreleased
+
+* Fix use of deprecated `Printf.kprintf` in OCaml 5.0
 
 ## v0.2.0 (2020-11-27)
 

--- a/src/ez_cmdliner/v2.ml
+++ b/src/ez_cmdliner/v2.ml
@@ -570,7 +570,7 @@ Overview of sub-commands::
               match path with
               | [] ->
                   if node.node_cmd != None then
-                    Printf.kprintf failwith
+                    Printf.ksprintf failwith
                       "The subcommand '%s' has been defined twice"
                       cmd.sub_name
                   ;


### PR DESCRIPTION
In recent versions of the compiler, `Printf.kprintf` is deprecated in favor of `Printf.ksprintf`. The latter being available since 3.09, it should not cause any trouble to use it instead.