### PR TITLE
Upgrade to cmdliner 2.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 * Fix use of deprecated `Printf.kprintf` in OCaml 5.0
+* Update to cmdliner.2.x
 
 ## v0.2.0 (2020-11-27)
 

--- a/dune-project
+++ b/dune-project
@@ -16,7 +16,7 @@
    (ocaml (>= 4.07.0))
    (ocplib_stuff ( >= 0.3 ))
    (ez_subst ( >= 0.1 ))
-   (cmdliner (and (>= 1.1.0) (< 2.0.0)))
+   (cmdliner (>= 2.0.0))
    ppx_inline_test
    ppx_expect
    odoc

--- a/opam/ez_cmdliner.opam
+++ b/opam/ez_cmdliner.opam
@@ -40,7 +40,7 @@ depends: [
   "dune" {>= "2.7.0"}
   "ocplib_stuff" {>= "0.3"}
   "ez_subst" {>= "0.1"}
-  "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "cmdliner" {>= "2.0.0"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}

--- a/src/ez_cmdliner/v2.ml
+++ b/src/ez_cmdliner/v2.ml
@@ -215,14 +215,15 @@ module EZCMD = struct
     | None -> `Help (`Pager, None) (* help about the program. *)
     | Some topic -> (
         let topics = ("topics" :: List.map fst more_topics) @ cmds in
-        let conv, _ = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
-        match conv topic with
-        | `Error e -> `Error (false, e)
-        | `Ok t when t = "topics" ->
+        let conv = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
+        let parse = Cmdliner.Arg.Conv.parser conv in
+        match parse topic with
+        | Error e -> `Error (false, e)
+        | Ok t when t = "topics" ->
             List.iter print_endline topics;
             `Ok ()
-        | `Ok t when List.mem t cmds -> `Help (man_format, Some t)
-        | `Ok t ->
+        | Ok t when List.mem t cmds -> `Help (man_format, Some t)
+        | Ok t ->
             let page =
               ((topic, 7, "", "", ""), `S topic :: List.assoc t more_topics)
             in


### PR DESCRIPTION
Fixes #22!

I'm not super familiar with `ez_cmdliner` yet but it seems the API is quite controlled so I don't think there's a risk of Cmdliner types leaking and causing breakage for `ez_cmdliner` users which should make this quite transparent of a change.